### PR TITLE
Update the aws_cost_and_usage_focus, aws_cost_and_usage_report and aws_cost_optimization_recommendation tables to display the column value as null instead of default value

### DIFF
--- a/tables/cost_and_usage_focus/cost_and_usage_focus_extractor.go
+++ b/tables/cost_and_usage_focus/cost_and_usage_focus_extractor.go
@@ -122,12 +122,12 @@ func (log *CostUsageFocus) mapValues(row map[string]string) error {
 					}
 
 				case reflect.Float64:
-					if floatVal, err := strconv.ParseFloat(value, 64); err == nil {
+					if floatVal, err := strconv.ParseFloat(value, 64); err == nil  && floatVal > 0{
 						structField.Set(reflect.ValueOf(&floatVal))
 					}
 
 				case reflect.Int64:
-					if intVal, err := strconv.ParseInt(value, 10, 64); err == nil {
+					if intVal, err := strconv.ParseInt(value, 10, 64); err == nil && intVal > 0{
 						structField.Set(reflect.ValueOf(&intVal))
 					}
 
@@ -141,7 +141,7 @@ func (log *CostUsageFocus) mapValues(row map[string]string) error {
 					// Handle map[string]string parsing
 					if elemType.Key().Kind() == reflect.String && elemType.Elem().Kind() == reflect.String {
 						var parsedMap map[string]string
-						if err := json.Unmarshal([]byte(value), &parsedMap); err == nil {
+						if err := json.Unmarshal([]byte(value), &parsedMap); err == nil && len(parsedMap) > 0 {
 							structField.Set(reflect.ValueOf(&parsedMap))
 						}
 					}

--- a/tables/cost_and_usage_focus/cost_and_usage_focus_extractor.go
+++ b/tables/cost_and_usage_focus/cost_and_usage_focus_extractor.go
@@ -122,12 +122,12 @@ func (log *CostUsageFocus) mapValues(row map[string]string) error {
 					}
 
 				case reflect.Float64:
-					if floatVal, err := strconv.ParseFloat(value, 64); err == nil  && floatVal > 0{
+					if floatVal, err := strconv.ParseFloat(value, 64); err == nil {
 						structField.Set(reflect.ValueOf(&floatVal))
 					}
 
 				case reflect.Int64:
-					if intVal, err := strconv.ParseInt(value, 10, 64); err == nil && intVal > 0{
+					if intVal, err := strconv.ParseInt(value, 10, 64); err == nil {
 						structField.Set(reflect.ValueOf(&intVal))
 					}
 

--- a/tables/cost_and_usage_report/cost_and_usage_report_extractor.go
+++ b/tables/cost_and_usage_report/cost_and_usage_report_extractor.go
@@ -211,11 +211,11 @@ func (value *CostUsageReport) MapValues(recordMap map[string]string) {
 						structField.Set(reflect.ValueOf(&val))
 					}
 				case reflect.Float64:
-					if floatVal, err := strconv.ParseFloat(strVal, 64); err == nil && floatVal > 0 {
+					if floatVal, err := strconv.ParseFloat(strVal, 64); err == nil {
 						structField.Set(reflect.ValueOf(&floatVal))
 					}
 				case reflect.Int64:
-					if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil && intVal > 0 {
+					if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 						structField.Set(reflect.ValueOf(&intVal))
 					}
 				case reflect.Struct:

--- a/tables/cost_and_usage_report/cost_and_usage_report_extractor.go
+++ b/tables/cost_and_usage_report/cost_and_usage_report_extractor.go
@@ -132,6 +132,23 @@ func extractFromCSV(reader io.Reader) ([]any, error) {
 		record := &CostUsageReport{}
 		record.MapValues(recordMap)
 
+		// We should have null value if the map value is empty
+		if len(*record.Product) == 0 {
+			record.Product = nil
+		}
+		if len(*record.CostCategory) == 0 {
+			record.CostCategory = nil
+		}
+		if len(*record.Reservation) == 0 {
+			record.Reservation = nil
+		}
+		if len(*record.ResourceTags) == 0 {
+			record.ResourceTags = nil
+		}
+		if len(*record.Discount) == 0 {
+			record.Discount = nil
+		}
+
 		// Append the record
 		records = append(records, record)
 	}
@@ -190,32 +207,21 @@ func (value *CostUsageReport) MapValues(recordMap map[string]string) {
 				switch elemType.Kind() {
 				case reflect.String:
 					val := strVal
-					if val == "" {
-						structField.Set(reflect.Zero(structField.Type())) // Set to nil
-					} else {
+					if val != "" {
 						structField.Set(reflect.ValueOf(&val))
 					}
 				case reflect.Float64:
-					if floatVal, err := strconv.ParseFloat(strVal, 64); err == nil {
+					if floatVal, err := strconv.ParseFloat(strVal, 64); err == nil && floatVal > 0 {
 						structField.Set(reflect.ValueOf(&floatVal))
-					} else {
-						defaultVal := float64(0)
-						structField.Set(reflect.ValueOf(&defaultVal))
 					}
 				case reflect.Int64:
-					if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
+					if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil && intVal > 0 {
 						structField.Set(reflect.ValueOf(&intVal))
-					} else {
-						defaultVal := int64(0)
-						structField.Set(reflect.ValueOf(&defaultVal))
 					}
 				case reflect.Struct:
 					if elemType == reflect.TypeOf(time.Time{}) {
 						if timeVal, err := time.Parse(time.RFC3339, strVal); err == nil {
 							structField.Set(reflect.ValueOf(&timeVal))
-						} else {
-							defaultVal := time.Time{}
-							structField.Set(reflect.ValueOf(&defaultVal))
 						}
 					}
 				}

--- a/tables/cost_optimization_recommendation/cost_optimization_recommendation_extractor.go
+++ b/tables/cost_optimization_recommendation/cost_optimization_recommendation_extractor.go
@@ -198,12 +198,12 @@ func (value *CostOptimizationRecommendation) MapValues(recordMap map[string]stri
 				}
 			case reflect.Int:
 				val, err := strconv.Atoi(strVal)
-				if err == nil && val > 0 {
+				if err == nil {
 					fieldVal.Set(reflect.ValueOf(&val))
 				}
 			case reflect.Float64:
 				val, err := strconv.ParseFloat(strVal, 64)
-				if err == nil && val > 0 {
+				if err == nil {
 					fieldVal.Set(reflect.ValueOf(&val))
 				}
 			case reflect.Bool:

--- a/tables/cost_optimization_recommendation/cost_optimization_recommendation_extractor.go
+++ b/tables/cost_optimization_recommendation/cost_optimization_recommendation_extractor.go
@@ -108,14 +108,6 @@ func extractFromCSV(reader io.Reader) ([]any, error) {
 		// Map the values to the record
 		record.MapValues(recordMap)
 
-		// We should have null value if the map value is empty
-		if len(*record.RecommendedResourceDetails) == 0 {
-			record.RecommendedResourceDetails = nil
-		}
-		if len(*record.CurrentResourceDetails) == 0 {
-			record.CurrentResourceDetails = nil
-		}
-
 		// Add the record to our list
 		records = append(records, record)
 	}

--- a/tables/cost_optimization_recommendation/cost_optimization_recommendation_extractor.go
+++ b/tables/cost_optimization_recommendation/cost_optimization_recommendation_extractor.go
@@ -108,6 +108,14 @@ func extractFromCSV(reader io.Reader) ([]any, error) {
 		// Map the values to the record
 		record.MapValues(recordMap)
 
+		// We should have null value if the map value is empty
+		if len(*record.RecommendedResourceDetails) == 0 {
+			record.RecommendedResourceDetails = nil
+		}
+		if len(*record.CurrentResourceDetails) == 0 {
+			record.CurrentResourceDetails = nil
+		}
+
 		// Add the record to our list
 		records = append(records, record)
 	}
@@ -193,15 +201,17 @@ func (value *CostOptimizationRecommendation) MapValues(recordMap map[string]stri
 			switch ptrType.Kind() {
 			case reflect.String:
 				val := strVal
-				fieldVal.Set(reflect.ValueOf(&val))
+				if val != "" {
+					fieldVal.Set(reflect.ValueOf(&val))
+				}
 			case reflect.Int:
 				val, err := strconv.Atoi(strVal)
-				if err == nil {
+				if err == nil && val > 0 {
 					fieldVal.Set(reflect.ValueOf(&val))
 				}
 			case reflect.Float64:
 				val, err := strconv.ParseFloat(strVal, 64)
-				if err == nil {
+				if err == nil && val > 0 {
 					fieldVal.Set(reflect.ValueOf(&val))
 				}
 			case reflect.Bool:


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>

```
> select distinct x_cost_categories, x_discounts from aws_cost_and_usage_focus;
+------------------------------------------------+-------------+
| x_cost_categories                              | x_discounts |
+------------------------------------------------+-------------+
| map[Test_Cost_Category:50 nagaraj_category:49] | <null>      |
+------------------------------------------------+-------------+

> select current_resource_details from aws_cost_optimization_recommendation;
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| current_resource_details                                                                                                                                                                                                                                                   >
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| <null>                                                                                                                                                                                                                                                                     >
| map[ebsVolume:map[configuration:map[attachmentState:Unattached performance:map[iops:0 throughput:0] storage:map[sizeInGb:8 type:gp3]] costCalculation:map[pricing:map[estimatedCostAfterDiscounts:0.768 estimatedCostBeforeDiscounts:0.768 estimatedDiscounts:map[otherDisc>
| map[ebsVolume:map[configuration:map[attachmentState:Unattached performance:map[iops:0 throughput:0] storage:map[sizeInGb:1 type:gp3]] costCalculation:map[pricing:map[estimatedCostAfterDiscounts:0.0959 estimatedCostBeforeDiscounts:0.0959 estimatedDiscounts:map[otherDi>
| map[ebsVolume:map[configuration:map[attachmentState:Unattached performance:map[iops:0 throughput:0] storage:map[sizeInGb:1 type:gp3]] costCalculation:map[pricing:map[estimatedCostAfterDiscounts:0.0842 estimatedCostBeforeDiscounts:0.0842 estimatedDiscounts:map[otherDi>


```
</details>
