### PR TITLE
Update file_layout syntax to use backticks for consistency in documentation

### DIFF
--- a/docs/sources/aws_s3_bucket.md
+++ b/docs/sources/aws_s3_bucket.md
@@ -53,7 +53,7 @@ partition "aws_cloudtrail_log" "my_logs_custom_path" {
   source "aws_s3_bucket" {
     connection  = connection.aws.logging_account
     bucket      = "aws-cloudtrail-logs-bucket"
-    file_layout = "CustomLogs/Dev/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz"
+    file_layout = `CustomLogs/Dev/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz`
   }
 }
 ```

--- a/docs/tables/aws_alb_access_log/index.md
+++ b/docs/tables/aws_alb_access_log/index.md
@@ -158,7 +158,7 @@ You can also collect ALB access logs from local files.
 partition "aws_alb_access_log" "local_logs" {
   source "file"  {
     paths       = ["/Users/myuser/elb_logs"]
-    file_layout = "%{DATA}.log.gz"
+    file_layout = `%{DATA}.log.gz`
   }
 }
 ```
@@ -187,7 +187,7 @@ partition "aws_alb_access_log" "my_logs_org" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "aws-alb-logs-bucket"
-    file_layout = "AWSLogs/o-aa111bb222/%{NUMBER:account_id}/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_app.%{DATA}.log.gz"
+    file_layout = `AWSLogs/o-aa111bb222/%{NUMBER:account_id}/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_app.%{DATA}.log.gz`
   }
 }
 ```
@@ -201,7 +201,7 @@ partition "aws_alb_access_log" "my_logs_account" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "aws-alb-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?123456789012/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_app.%{DATA}.log.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?123456789012/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_app.%{DATA}.log.gz`
   }
 }
 ```
@@ -215,7 +215,7 @@ partition "aws_alb_access_log" "my_logs_region" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "aws-alb-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_app.%{DATA}.log.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_app.%{DATA}.log.gz`
   }
 }
 ```
@@ -229,7 +229,7 @@ partition "aws_alb_access_log" "my_logs_regions" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "aws-alb-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/(us-east-1|us-east-2)/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_app.%{DATA}.log.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/(us-east-1|us-east-2)/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_app.%{DATA}.log.gz`
   }
 }
 ```

--- a/docs/tables/aws_clb_access_log/index.md
+++ b/docs/tables/aws_clb_access_log/index.md
@@ -145,7 +145,7 @@ partition "aws_clb_access_log" "my_clb_logs_prefix" {
 partition "aws_clb_access_log" "local_logs" {
   source "file"  {
     paths       = ["/Users/myuser/clb_logs"]
-    file_layout = "%{DATA}.log"
+    file_layout = `%{DATA}.log`
   }
 }
 ```
@@ -172,7 +172,7 @@ partition "aws_clb_access_log" "my_logs_org" {
   source "aws_s3_bucket" {
     connection  = connection.aws.logging_account
     bucket      = "aws-clb-logs-bucket"
-    file_layout = "AWSLogs/o-aa111bb222/%{NUMBER:account_id}/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_%{DATA}.log"
+    file_layout = `AWSLogs/o-aa111bb222/%{NUMBER:account_id}/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_%{DATA}.log`
   }
 }
 ```
@@ -184,7 +184,7 @@ partition "aws_clb_access_log" "my_logs_account" {
   source "aws_s3_bucket" {
     connection  = connection.aws.logging_account
     bucket      = "aws-clb-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?123456789012/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_%{DATA}.log"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?123456789012/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_%{DATA}.log`
   }
 }
 ```
@@ -196,7 +196,7 @@ partition "aws_clb_access_log" "my_logs_region" {
   source "aws_s3_bucket" {
     connection  = connection.aws.logging_account
     bucket      = "aws-clb-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_%{DATA}.log"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_%{DATA}.log`
   }
 }
 ```
@@ -208,7 +208,7 @@ partition "aws_clb_access_log" "my_logs_regions" {
   source "aws_s3_bucket" {
     connection  = connection.aws.logging_account
     bucket      = "aws-clb-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/(us-east-1|us-east-2)/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_%{DATA}.log"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/(us-east-1|us-east-2)/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_%{DATA}.log`
   }
 }
 ```

--- a/docs/tables/aws_cloudtrail_log/index.md
+++ b/docs/tables/aws_cloudtrail_log/index.md
@@ -149,7 +149,7 @@ You can also collect CloudTrail logs from local files, like the [flaws.cloud pub
 partition "aws_cloudtrail_log" "local_logs" {
   source "file"  {
     paths       = ["/Users/myuser/cloudtrail_logs"]
-    file_layout = "%{DATA}.json.gz"
+    file_layout = `%{DATA}.json.gz`
   }
 }
 ```
@@ -179,7 +179,7 @@ partition "aws_cloudtrail_log" "my_logs_org" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "cloudtrail-s3-log-bucket"
-    file_layout = "AWSLogs/o-aa111bb222/%{NUMBER:account_id}/CloudTrail/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz"
+    file_layout = `AWSLogs/o-aa111bb222/%{NUMBER:account_id}/CloudTrail/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz`
   }
 }
 ```
@@ -193,7 +193,7 @@ partition "aws_cloudtrail_log" "my_logs_account" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "cloudtrail-s3-log-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?123456789012/CloudTrail/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?123456789012/CloudTrail/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz`
   }
 }
 ```
@@ -207,7 +207,7 @@ partition "aws_cloudtrail_log" "my_logs_region" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "cloudtrail-s3-log-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/CloudTrail/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/CloudTrail/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz`
   }
 }
 ```
@@ -220,7 +220,7 @@ For all accounts, collect logs from us-east-1 and us-east-2.
 partition "aws_cloudtrail_log" "my_logs_regions" {
   source "aws_s3_bucket"  {
     bucket      = "cloudtrail-s3-log-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/CloudTrail/(us-east-1|us-east-2)/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/CloudTrail/(us-east-1|us-east-2)/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz`
   }
 }
 ```

--- a/docs/tables/aws_cost_and_usage_focus/index.md
+++ b/docs/tables/aws_cost_and_usage_focus/index.md
@@ -159,7 +159,7 @@ partition "aws_cost_and_usage_focus" "specific_cur_focus" {
     connection  = connection.aws.billing_account
     bucket      = "aws-cur-org-bucket"
     prefix      = "my/prefix/"
-    file_layout = "my-focus-export/data/%{DATA:partition}/(?:%{TIMESTAMP_ISO8601:timestamp}-%{UUID:execution_id}/)?%{DATA:filename}.csv.gz"
+    file_layout = `my-focus-export/data/%{DATA:partition}/(?:%{TIMESTAMP_ISO8601:timestamp}-%{UUID:execution_id}/)?%{DATA:filename}.csv.gz`
   }
 }
 ```
@@ -172,7 +172,7 @@ You can also collect reports from local files.
 partition "aws_cost_and_usage_focus" "local_cur_focus" {
   source "file"  {
     paths       = ["/Users/myuser/aws_cur"]
-    file_layout = "%{DATA}.csv.gz"
+    file_layout = `%{DATA}.csv.gz`
   }
 }
 ```

--- a/docs/tables/aws_cost_and_usage_report/index.md
+++ b/docs/tables/aws_cost_and_usage_report/index.md
@@ -163,7 +163,7 @@ partition "aws_cost_and_usage_report" "specific_cur_2_0" {
     connection  = connection.aws.billing_account
     bucket      = "aws-cur-billing-bucket"
     prefix      = "my/prefix/"
-    file_layout = "my-cur-2-0-export/data/%{DATA:partition}/?(?:%{DATA:timestamp}-%{DATA:execution_id}/)?%{DATA:file_name}.csv.gz"
+    file_layout = `my-cur-2-0-export/data/%{DATA:partition}/?(?:%{DATA:timestamp}-%{DATA:execution_id}/)?%{DATA:file_name}.csv.gz`
   }
 }
 ```
@@ -178,7 +178,7 @@ partition "aws_cost_and_usage_report" "specific_cur_legacy" {
     connection  = connection.aws.billing_account
     bucket      = "aws-cur-billing-bucket"
     prefix      = "my/prefix/"
-    file_layout = "my-cur-legacy-export/%{INT:from_date}-%{INT:to_date}/(?:%{DATA:assembly_id}/)?%{DATA:file_name}.csv.zip"
+    file_layout = `my-cur-legacy-export/%{INT:from_date}-%{INT:to_date}/(?:%{DATA:assembly_id}/)?%{DATA:file_name}.csv.zip`
   }
 }
 ```
@@ -191,7 +191,7 @@ You can also reports from local files.
 partition "aws_cost_and_usage_report" "local_cur" {
   source "file"  {
     paths       = ["/Users/myuser/aws_cur"]
-    file_layout = "%{DATA}.csv.gz"
+    file_layout = `%{DATA}.csv.gz`
   }
 }
 ```

--- a/docs/tables/aws_cost_optimization_recommendation/index.md
+++ b/docs/tables/aws_cost_optimization_recommendation/index.md
@@ -162,7 +162,7 @@ partition "aws_cost_optimization_recommendation" "specific_recommendations" {
     connection  = connection.aws.billing_account
     bucket      = "aws-cost-optimization-recommendations-bucket"
     prefix      = "my/prefix/"
-    file_layout = "my-recommendations-export/data/%{DATA:partition}/(?:%{TIMESTAMP_ISO8601:timestamp}-%{UUID:execution_id}/)?%{DATA:filename}.csv.gz"
+    file_layout = `my-recommendations-export/data/%{DATA:partition}/(?:%{TIMESTAMP_ISO8601:timestamp}-%{UUID:execution_id}/)?%{DATA:filename}.csv.gz`
   }
 }
 ```
@@ -175,7 +175,7 @@ You can also collect AWS cost optimization recommendations from local files.
 partition "aws_cost_optimization_recommendation" "local_recommendations" {
   source "file"  {
     paths       = ["/Users/myuser/aws_recommendations"]
-    file_layout = "%{DATA}.csv.gz"
+    file_layout = `%{DATA}.csv.gz`
   }
 }
 ```

--- a/docs/tables/aws_guardduty_finding/index.md
+++ b/docs/tables/aws_guardduty_finding/index.md
@@ -150,7 +150,7 @@ You can also collect GuardDuty findings from local files.
 partition "aws_guardduty_finding" "local_findings" {
   source "file"  {
     paths       = ["/Users/myuser/guardduty_findings"]
-    file_layout = "%{DATA}.jsonl.gz"
+    file_layout = `%{DATA}.jsonl.gz`
   }
 }
 ```
@@ -179,7 +179,7 @@ partition "aws_guardduty_finding" "my_findings_org" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.security_account
     bucket      = "guardduty-findings-bucket"
-    file_layout = "AWSLogs/o-aa111bb222/%{NUMBER:account_id}/GuardDuty/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.jsonl.gz"
+    file_layout = `AWSLogs/o-aa111bb222/%{NUMBER:account_id}/GuardDuty/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.jsonl.gz`
   }
 }
 ```
@@ -193,7 +193,7 @@ partition "aws_guardduty_finding" "my_findings_account" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.security_account
     bucket      = "guardduty-findings-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?123456789012/GuardDuty/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.jsonl.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?123456789012/GuardDuty/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.jsonl.gz`
   }
 }
 ```
@@ -207,7 +207,7 @@ partition "aws_guardduty_finding" "my_findings_region" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.security_account
     bucket      = "guardduty-findings-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/GuardDuty/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.jsonl.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/GuardDuty/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.jsonl.gz`
   }
 }
 ```

--- a/docs/tables/aws_nlb_access_log/index.md
+++ b/docs/tables/aws_nlb_access_log/index.md
@@ -151,7 +151,7 @@ You can also collect NLB access logs from local files.
 partition "aws_nlb_access_log" "local_logs" {
   source "file"  {
     paths       = ["/Users/myuser/elb_logs"]
-    file_layout = "%{DATA}.log.gz"
+    file_layout = `%{DATA}.log.gz`
   }
 }
 ```
@@ -180,7 +180,7 @@ partition "aws_nlb_access_log" "my_logs_org" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "aws-nlb-logs-bucket"
-    file_layout = "AWSLogs/o-aa111bb222/%{NUMBER:account_id}/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_net.%{DATA}.log.gz"
+    file_layout = `AWSLogs/o-aa111bb222/%{NUMBER:account_id}/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_net.%{DATA}.log.gz`
   }
 }
 ```
@@ -194,7 +194,7 @@ partition "aws_nlb_access_log" "my_logs_account" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "aws-nlb-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?123456789012/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_net.%{DATA}.log.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?123456789012/elasticloadbalancing/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_net.%{DATA}.log.gz`
   }
 }
 ```
@@ -208,7 +208,7 @@ partition "aws_nlb_access_log" "my_logs_region" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "aws-nlb-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_net.%{DATA}.log.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_net.%{DATA}.log.gz`
   }
 }
 ```
@@ -222,7 +222,7 @@ partition "aws_nlb_access_log" "my_logs_regions" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.logging_account
     bucket      = "aws-nlb-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/(us-east-1|us-east-2)/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_net.%{DATA}.log.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/elasticloadbalancing/(us-east-1|us-east-2)/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{NUMBER:account_id}_elasticloadbalancing_%{DATA:region}_net.%{DATA}.log.gz`
   }
 }
 ```

--- a/docs/tables/aws_s3_server_access_log/index.md
+++ b/docs/tables/aws_s3_server_access_log/index.md
@@ -134,7 +134,7 @@ You can also collect logs from local files.
 partition "aws_s3_server_access_log" "my_s3_logs" {
   source "file"  {
     paths       = ["/Users/myuser/s3_server_access_log"]
-    file_layout = "%{DATA}.txt"
+    file_layout = `%{DATA}.txt`
   }
 }
 ```

--- a/docs/tables/aws_vpc_flow_log/index.md
+++ b/docs/tables/aws_vpc_flow_log/index.md
@@ -148,7 +148,7 @@ You can also collect VPC Flow Logs from local files.
 partition "aws_vpc_flow_log" "local_logs" {
   source "file"  {
     paths       = ["/Users/myuser/vpc_flow_logs"]
-    file_layout = "%{DATA}.json.gz"
+    file_layout = `%{DATA}.json.gz`
   }
 }
 ```
@@ -162,7 +162,7 @@ partition "aws_vpc_flow_log" "my_logs_org" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.vpc_logging
     bucket      = "vpc-flow-logs-bucket"
-    file_layout = "AWSLogs/o-aa111bb222/%{NUMBER:account_id}/vpcflowlogs/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/(%{NUMBER:hour}/)?%{DATA}.log.gz"
+    file_layout = `AWSLogs/o-aa111bb222/%{NUMBER:account_id}/vpcflowlogs/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/(%{NUMBER:hour}/)?%{DATA}.log.gz`
   }
 }
 ```
@@ -176,7 +176,7 @@ partition "aws_vpc_flow_log" "my_logs_account" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.vpc_logging
     bucket      = "vpc-flow-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?123456789012/vpcflowlogs/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/(%{NUMBER:hour}/)?%{DATA}.log.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?123456789012/vpcflowlogs/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/(%{NUMBER:hour}/)?%{DATA}.log.gz`
   }
 }
 ```
@@ -190,7 +190,7 @@ partition "aws_vpc_flow_log" "my_logs_region" {
   source "aws_s3_bucket"  {
     connection  = connection.aws.vpc_logging
     bucket      = "vpc-flow-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/vpcflowlogs/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/(%{NUMBER:hour}/)?%{DATA}.log.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/vpcflowlogs/us-east-1/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/(%{NUMBER:hour}/)?%{DATA}.log.gz`
   }
 }
 ```

--- a/docs/tables/aws_waf_traffic_log/index.md
+++ b/docs/tables/aws_waf_traffic_log/index.md
@@ -146,7 +146,7 @@ You can also collect AWS WAF logs from local files.
 partition "aws_waf_traffic_log" "local_logs" {
   source "file"  {
     paths       = ["/Users/myuser/aws_waf_traffic_logs"]
-    file_layout = "%{DATA}.json.gz"
+    file_layout = `%{DATA}.json.gz`
   }
 }
 ```
@@ -160,7 +160,7 @@ partition "aws_waf_traffic_log" "my_logs_org" {
   source "aws_s3_bucket" {
     connection  = connection.aws.security_account
     bucket      = "waf-traffic-logs-bucket"
-    file_layout = "AWSLogs/o-aa111bb222/%{NUMBER:account_id}/WAFLogs/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{HOUR:hour}/%{MINUTE:minute}/%{DATA}.json.gz"
+    file_layout = `AWSLogs/o-aa111bb222/%{NUMBER:account_id}/WAFLogs/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{HOUR:hour}/%{MINUTE:minute}/%{DATA}.json.gz`
   }
 }
 ```
@@ -174,7 +174,7 @@ partition "aws_waf_traffic_log" "my_logs_account" {
   source "aws_s3_bucket" {
     connection  = connection.aws.security_account
     bucket      = "waf-traffic-logs-bucket"
-    file_layout = "AWSLogs/(%{DATA:org_id}/)?123456789012/WAFLogs/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{HOUR:hour}/%{MINUTE:minute}/%{DATA}.json.gz"
+    file_layout = `AWSLogs/(%{DATA:org_id}/)?123456789012/WAFLogs/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{HOUR:hour}/%{MINUTE:minute}/%{DATA}.json.gz`
   }
 }
 ```
@@ -187,7 +187,7 @@ You can also collect logs from local files.
 partition "aws_waf_traffic_log" "my_logs" {
   source "file"  {
     paths       = ["/Users/myuser/aws_waf_traffic_log"]
-    file_layout = "%{DATA}.txt"
+    file_layout = `%{DATA}.txt`
   }
 }
 ```


### PR DESCRIPTION


# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
