### PR TITLE
Added the config arg `log_stream_names` to the CloudWatch source

### DIFF
--- a/docs/sources/aws_cloudwatch_log_group.md
+++ b/docs/sources/aws_cloudwatch_log_group.md
@@ -29,9 +29,24 @@ partition "aws_cloudtrail_log" "cw_log_group_logs" {
 }
 ```
 
-### Collect CloudTrail logs with a prefix
+### Collect CloudTrail logs for a specific account and region
 
 Collect CloudTrail logs for account ID `456789012345` in us-east-1.
+
+```hcl
+partition "aws_cloudtrail_log" "cw_log_group_logs_prefix" {
+  source "aws_cloudwatch_log_group" {
+    connection        = connection.aws.default
+    log_group_name    = "aws-cloudtrail-logs-123456789012-fd33b044"
+    log_stream_names  = ["456789012345_CloudTrail_us-east-1*"]
+    region            = "us-east-1"
+  }
+}
+```
+
+### Collect CloudTrail logs for all regions in an account
+
+Collect CloudTrail logs for account ID `456789012345` for all regions.
 
 ```hcl
 partition "aws_cloudtrail_log" "cw_log_group_logs_prefix" {
@@ -50,5 +65,5 @@ partition "aws_cloudtrail_log" "cw_log_group_logs_prefix" {
 | ---------------- | ---------------- | -------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
 | connection       | `connection.aws` | No       | `connection.aws.default` | The [AWS connection](https://hub.tailpipe.io/plugins/turbot/aws#connection-credentials) to use to connect to the AWS account. |
 | log_group_name   | String           | Yes      |                          | The name of the CloudWatch log group to collect logs from.                                                                    |
-| log_stream_names | []String{}       | No       |                          | Collect logs from log streams whose names begin the specified prefix.                                                         |
+| log_stream_names | List(String)     | No       |                          | Collect logs from log streams whose names begin the specified prefix.                                                         |
 | region           | String           | Yes      |                          | The AWS region where the log group is located.                                                                                |

--- a/docs/sources/aws_cloudwatch_log_group.md
+++ b/docs/sources/aws_cloudwatch_log_group.md
@@ -38,7 +38,7 @@ partition "aws_cloudtrail_log" "cw_log_group_logs_prefix" {
   source "aws_cloudwatch_log_group" {
     connection        = connection.aws.default
     log_group_name    = "aws-cloudtrail-logs-123456789012-fd33b044"
-    log_stream_prefix = "456789012345_CloudTrail_us-east-1"
+    log_stream_names  = ["456789012345_CloudTrail_*"]
     region            = "us-east-1"
   }
 }
@@ -46,9 +46,9 @@ partition "aws_cloudtrail_log" "cw_log_group_logs_prefix" {
 
 ## Arguments
 
-| Argument          | Type             | Required | Default                  | Description                                                                                                                   |
-| ----------------- | ---------------- | -------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| connection        | `connection.aws` | No       | `connection.aws.default` | The [AWS connection](https://hub.tailpipe.io/plugins/turbot/aws#connection-credentials) to use to connect to the AWS account. |
-| log_group_name    | String           | Yes      |                          | The name of the CloudWatch log group to collect logs from.                                                                    |
-| log_stream_prefix | String           | No       |                          | Collect logs from log streams whose names begin the specified prefix.                                                         |
-| region            | String           | Yes      |                          | The AWS region where the log group is located.                                                                                |
+| Argument         | Type             | Required | Default                  | Description                                                                                                                   |
+| ---------------- | ---------------- | -------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| connection       | `connection.aws` | No       | `connection.aws.default` | The [AWS connection](https://hub.tailpipe.io/plugins/turbot/aws#connection-credentials) to use to connect to the AWS account. |
+| log_group_name   | String           | Yes      |                          | The name of the CloudWatch log group to collect logs from.                                                                    |
+| log_stream_names | []String{}       | No       |                          | Collect logs from log streams whose names begin the specified prefix.                                                         |
+| region           | String           | Yes      |                          | The AWS region where the log group is located.                                                                                |

--- a/docs/tables/aws_cloudtrail_log/index.md
+++ b/docs/tables/aws_cloudtrail_log/index.md
@@ -143,7 +143,7 @@ partition "aws_cloudtrail_log" "my_logs_prefix" {
 
 ### Collect logs from a CloudWatch log group
 
-Collect CloudTrail logs stored in a CloudWatch log group.
+Collect CloudTrail logs from a basic CloudWatch log group configuration without any stream filtering.
 
 ```hcl
 partition "aws_cloudtrail_log" "cw_log_group_logs" {
@@ -155,17 +155,32 @@ partition "aws_cloudtrail_log" "cw_log_group_logs" {
 }
 ```
 
-### Collect logs from a CloudWatch log group with a log stream prefix
+### Collect CloudTrail logs from CloudWatch for a specific region
 
-Collect CloudTrail logs for account ID `456789012345` in us-east-1.
+Collect CloudTrail logs for a specific account (456789012345) in a particular region (us-east-1) by using an exact log stream name match.
 
 ```hcl
-partition "aws_cloudtrail_log" "cw_log_group_logs_prefix" {
+partition "aws_cloudtrail_log" "cw_log_group_logs_specific" {
   source "aws_cloudwatch_log_group" {
-    connection        = connection.aws.default
-    log_group_name    = "aws-cloudtrail-logs-123456789012-fd33b044"
-    log_stream_names  = ["456789012345_CloudTrail_*"]
-    region            = "us-east-1"
+    connection = connection.aws.default
+    log_group_name = "aws-cloudtrail-logs-123456789012-fd33b044"
+    log_stream_names = ["456789012345_CloudTrail_us-east-1"]
+    region = "us-east-1"
+  }
+}
+```
+
+### Collect CloudTrail logs from CloudWatch for all regions
+
+Collect CloudTrail logs for a specific account (456789012345) across all regions by using a wildcard pattern in the log stream name.
+
+```hcl
+partition "aws_cloudtrail_log" "cw_log_group_logs_all_regions" {
+  source "aws_cloudwatch_log_group" {
+    connection = connection.aws.default
+    log_group_name = "aws-cloudtrail-logs-123456789012-fd33b044"
+    log_stream_names = ["456789012345_CloudTrail_*"]
+    region = "us-east-1"
   }
 }
 ```
@@ -260,6 +275,6 @@ partition "aws_cloudtrail_log" "my_logs_regions" {
 
 This table sets the following defaults for the [aws_s3_bucket source](https://hub.tailpipe.io/plugins/turbot/aws/sources/aws_s3_bucket#arguments):
 
-| Argument      | Default |
-|---------------|---------|
-| file_layout   | `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/CloudTrail/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz` |
+| Argument    | Default                                                                                                                                   |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| file_layout | `AWSLogs/(%{DATA:org_id}/)?%{NUMBER:account_id}/CloudTrail/%{DATA:region}/%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}/%{DATA}.json.gz` |

--- a/docs/tables/aws_cloudtrail_log/index.md
+++ b/docs/tables/aws_cloudtrail_log/index.md
@@ -164,7 +164,7 @@ partition "aws_cloudtrail_log" "cw_log_group_logs_prefix" {
   source "aws_cloudwatch_log_group" {
     connection        = connection.aws.default
     log_group_name    = "aws-cloudtrail-logs-123456789012-fd33b044"
-    log_stream_prefix = "456789012345_CloudTrail_us-east-1"
+    log_stream_names  = ["456789012345_CloudTrail_*"]
     region            = "us-east-1"
   }
 }

--- a/docs/tables/aws_waf_traffic_log/index.md
+++ b/docs/tables/aws_waf_traffic_log/index.md
@@ -161,7 +161,7 @@ partition "aws_waf_traffic_log" "cw_log_group_logs_prefix" {
   source "aws_cloudwatch_log_group" {
     connection        = connection.aws.logging_account
     log_group_name    = "aws-waf-log-testLogGroup2"
-    log_stream_prefix = "us-east-1_TestWebACL_"
+    log_stream_names  = ["us-east-1_TestWebACL_*"]
     region            = "us-east-1"
   }
 }

--- a/docs/tables/aws_waf_traffic_log/index.md
+++ b/docs/tables/aws_waf_traffic_log/index.md
@@ -140,7 +140,7 @@ partition "aws_waf_traffic_log" "my_logs_prefix" {
 
 ### Collect logs from a CloudWatch log group
 
-This example shows how to collect WAF traffic logs from a basic CloudWatch log group configuration without any log stream filtering.
+Collect WAF traffic logs from a CloudWatch log group without any log stream filtering.
 
 ```hcl
 partition "aws_waf_traffic_log" "cw_log_group_logs" {

--- a/docs/tables/aws_waf_traffic_log/index.md
+++ b/docs/tables/aws_waf_traffic_log/index.md
@@ -152,7 +152,7 @@ partition "aws_waf_traffic_log" "cw_log_group_logs" {
 }
 ```
 
-### Collect WAF logs from CloudWatch from a specific log stream
+### Collect logs from a CloudWatch log group with a log stream
 
 Collect WAF traffic logs for a specific Web ACL in us-east-1 by using an exact log stream name match.
 

--- a/docs/tables/aws_waf_traffic_log/index.md
+++ b/docs/tables/aws_waf_traffic_log/index.md
@@ -85,7 +85,7 @@ limit 10;
 
 ### Blocked Requests With SQL Injection
 
-Find web requests that matched AWS WAF’s SQL injection detection.
+Find web requests that matched AWS WAF's SQL injection detection.
 
 ```sql
 select
@@ -140,7 +140,7 @@ partition "aws_waf_traffic_log" "my_logs_prefix" {
 
 ### Collect logs from a CloudWatch log group
 
-Collect logs stored in a CloudWatch log group.
+This example shows how to collect WAF traffic logs from a basic CloudWatch log group configuration without any log stream filtering.
 
 ```hcl
 partition "aws_waf_traffic_log" "cw_log_group_logs" {
@@ -152,17 +152,32 @@ partition "aws_waf_traffic_log" "cw_log_group_logs" {
 }
 ```
 
-### Collect logs from a CloudWatch log group with a log stream prefix
+### Collect WAF logs from CloudWatch from a specific log stream
 
-Collect logs for web ACL `TestWebACL` in us-east-1.
+Collect WAF traffic logs for a specific Web ACL in us-east-1 by using an exact log stream name match.
 
 ```hcl
-partition "aws_waf_traffic_log" "cw_log_group_logs_prefix" {
+partition "aws_waf_traffic_log" "cw_log_group_logs_specific" {
   source "aws_cloudwatch_log_group" {
-    connection        = connection.aws.logging_account
-    log_group_name    = "aws-waf-log-testLogGroup2"
-    log_stream_names  = ["us-east-1_TestWebACL_*"]
-    region            = "us-east-1"
+    connection = connection.aws.logging_account
+    log_group_name = "aws-waf-log-testLogGroup2"
+    log_stream_names = ["us-east-1_TestWebACL_123456"]
+    region = "us-east-1"
+  }
+}
+```
+
+### Collect WAF logs from CloudWatch for all Web ACLs in a region
+
+Collect WAF traffic logs for all Web ACLs in us-east-1 by using a wildcard pattern in the log stream name.
+
+```hcl
+partition "aws_waf_traffic_log" "cw_log_group_logs_all" {
+  source "aws_cloudwatch_log_group" {
+    connection = connection.aws.logging_account
+    log_group_name = "aws-waf-log-testLogGroup2"
+    log_stream_names = ["us-east-1_*"]
+    region = "us-east-1"
   }
 }
 ```

--- a/sources/cloudwatch_log_group/cloudwatch_log_group_source.go
+++ b/sources/cloudwatch_log_group/cloudwatch_log_group_source.go
@@ -122,10 +122,6 @@ func (s *AwsCloudWatchLogGroupSource) Collect(ctx context.Context) error {
 
 	// Process each log stream
 	for _, ls := range logStreamCollection {
-		if ls.LogStreamName == nil {
-			s.errorList = append(s.errorList, fmt.Errorf("skipping stream with nil name in log group %s", s.Config.LogGroupName))
-			continue
-		}
 
 		slog.Info("Processing stream", "stream", *ls.LogStreamName)
 		// Set up source enrichment fields for the current stream

--- a/sources/cloudwatch_log_group/cloudwatch_log_group_source.go
+++ b/sources/cloudwatch_log_group/cloudwatch_log_group_source.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -74,6 +75,20 @@ func (s *AwsCloudWatchLogGroupSource) Identifier() string {
 	return AwsCloudwatchLogGroupSourceIdentifier
 }
 
+func matchesAnyPattern(target string, patterns []string) bool {
+	for _, pattern := range patterns {
+		match, err := filepath.Match(pattern, target)
+		if err != nil {
+			slog.Error("error matching pattern '%s': %v\n", pattern, err)
+			continue
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
 // Collect retrieves log events from CloudWatch log streams within the specified time range
 // It handles pagination, maintains collection state, and processes events incrementally
 func (s *AwsCloudWatchLogGroupSource) Collect(ctx context.Context) error {
@@ -81,6 +96,26 @@ func (s *AwsCloudWatchLogGroupSource) Collect(ctx context.Context) error {
 	logStreamCollection, err := s.getLogStreamsToCollect(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to collect log streams, %w", err)
+	}
+
+	// Filter out the log streams that are not in the list of log stream names
+	if len(s.Config.LogStreamNames) > 0 {
+		filteredLogStreamCollection := []cwTypes.LogStream{}
+		logStreamNames := s.Config.LogStreamNames
+
+		for _, ls := range logStreamCollection {
+			if ls.LogStreamName == nil {
+				s.errorList = append(s.errorList, fmt.Errorf("skipping stream with nil name in log group %s", s.Config.LogGroupName))
+				continue
+			}
+
+			if matchesAnyPattern(*ls.LogStreamName, logStreamNames) {
+				filteredLogStreamCollection = append(filteredLogStreamCollection, ls)
+			}
+		}
+
+		// Use the filtered collection
+		logStreamCollection = filteredLogStreamCollection
 	}
 
 	slog.Info("Starting collection", "total_streams", len(logStreamCollection))
@@ -206,9 +241,8 @@ func (s *AwsCloudWatchLogGroupSource) getLogStreamsToCollect(ctx context.Context
 
 	for {
 		input := &cloudwatchlogs.DescribeLogStreamsInput{
-			LogGroupName:        &s.Config.LogGroupName,
-			LogStreamNamePrefix: s.Config.LogStreamPrefix,
-			NextToken:           nextToken,
+			LogGroupName: &s.Config.LogGroupName,
+			NextToken:    nextToken,
 		}
 
 		output, err := s.client.DescribeLogStreams(ctx, input)
@@ -218,7 +252,7 @@ func (s *AwsCloudWatchLogGroupSource) getLogStreamsToCollect(ctx context.Context
 
 		// Break if no streams found in this page
 		if len(output.LogStreams) == 0 {
-			slog.Debug("No log streams found", "logGroupName", s.Config.LogGroupName, "logStreamPrefix", s.Config.LogStreamPrefix)
+			slog.Debug("No log streams found", "logGroupName", s.Config.LogGroupName)
 			break
 		}
 
@@ -226,14 +260,14 @@ func (s *AwsCloudWatchLogGroupSource) getLogStreamsToCollect(ctx context.Context
 
 		// Break if no more pages
 		if output.NextToken == nil {
-			slog.Debug("No more log streams to fetch", "logGroupName", s.Config.LogGroupName, "logStreamPrefix", s.Config.LogStreamPrefix, "total_streams", len(logStreams))
+			slog.Debug("No more log streams to fetch", "logGroupName", s.Config.LogGroupName, "total_streams", len(logStreams))
 			break
 		}
 		nextToken = output.NextToken
 	}
 
 	if len(logStreams) == 0 {
-		slog.Info("No log streams found to collect", "logGroupName", s.Config.LogGroupName, "logStreamPrefix", s.Config.LogStreamPrefix)
+		slog.Info("No log streams found to collect", "logGroupName", s.Config.LogGroupName)
 	}
 
 	return logStreams, nil

--- a/sources/cloudwatch_log_group/cloudwatch_log_group_source_config.go
+++ b/sources/cloudwatch_log_group/cloudwatch_log_group_source_config.go
@@ -9,8 +9,10 @@ import "fmt"
 type AwsCloudWatchLogGroupSourceConfig struct {
 	// LogGroupName is the name of the CloudWatch log group to collect logs from (required)
 	LogGroupName string `hcl:"log_group_name"`
-	// LogStreamPrefix optionally filters log streams by their name prefix
-	LogStreamPrefix *string `hcl:"log_stream_prefix"`
+	// LogStreamNames optionally filters log streams by their names. Supports wildcards (*).
+	// If not specified, logs from all available streams will be collected.
+	// Example: ["456789012345_CloudTrail_*", "123456789012_CloudTrail_us-east-1"]
+	LogStreamNames []string `hcl:"log_stream_names,optional"`
 	// Region specifies the AWS region where the log group exists
 	// If not provided, defaults to us-east-1
 	Region *string `hcl:"region"`

--- a/sources/cloudwatch_log_group/cloudwatch_log_group_source_config.go
+++ b/sources/cloudwatch_log_group/cloudwatch_log_group_source_config.go
@@ -14,7 +14,7 @@ type AwsCloudWatchLogGroupSourceConfig struct {
 	// Example: ["456789012345_CloudTrail_*", "123456789012_CloudTrail_us-east-1"]
 	LogStreamNames []string `hcl:"log_stream_names,optional"`
 	// Region specifies the AWS region where the log group exists
-	// If not provided, defaults to us-east-1
+	// If not provided, an error will be raised "region is required and cannot be empty".
 	Region *string `hcl:"region"`
 }
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```

Config with matched patter:

partition "aws_waf_traffic_log" "cw_waf" {
  source "aws_cloudwatch_log_group"  {
    connection = connection.aws.nagraj
    log_group_name = "aws-waf-logs-test-tp-01"
    log_stream_names = ["us-east-1_*"]
    region = "us-east-1"
  }
}

Result: 

tailpipe collect aws_waf_traffic_log.cw_waf --from 2025-01-01

Collecting logs for aws_waf_traffic_log.cw_waf from 2025-01-01 

Rows:
  Received: 10
  Enriched: 10
  Saved:    10

Files:
  Compacted: 1 => 1

Completed: 2s

Config with unmatched pattern:

partition "aws_waf_traffic_log" "cw_waf" {
  source "aws_cloudwatch_log_group"  {
    connection = connection.aws.nagraj
    log_group_name = "aws-waf-logs-test-tp-01"
    log_stream_names = ["us-east-2_*"] // unmatched pattern
    region = "us-east-1"
  }
}


Result:

tailpipe collect aws_waf_traffic_log.cw_waf --from 2025-01-01    

Collecting logs for aws_waf_traffic_log.cw_waf from 2025-01-01 

Rows:
  Received: 0
  Enriched: 0
  Saved:    0

Files:
  No files to compact.

Completed: 3s
```
</details>
