### PR TITLE
Fix error with adding the empty header value for the table aws_cost_and_usage_report while collecting the rows

### DIFF
--- a/tables/cost_and_usage_report/cost_and_usage_report_mapper.go
+++ b/tables/cost_and_usage_report/cost_and_usage_report_mapper.go
@@ -493,10 +493,10 @@ func (c *CostAndUsageReportMapper) Map(_ context.Context, a any, opts ...mappers
 func (c *CostAndUsageReportMapper) OnHeader(header []string) {
 	newHeaders := make([]string, len(header))
 	// set headers but normalize first
-	for _, h := range header {
+	for i, h := range header {
 		v := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(h, "/", "_"), ":", "_"), " ", "_"), ".", "_"), "a_r_n", "arn")
 		v = strcase.SnakeCase(v)
-		newHeaders = append(newHeaders, strings.ToLower(v))
+		newHeaders[i] = strings.ToLower(v)
 	}
 	c.headers = newHeaders
 }


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>

```
S3 Bucket Source:
> select count(*) from aws_cost_and_usage_report;
+--------------+
| count_star() |
+--------------+
| 1,440,373    |
+--------------+

Legacy to cur:

tpc aws_cost_and_usage_report.legacy_to_20 --from 2025-03-01

Collecting logs for aws_cost_and_usage_report.legacy_to_20 from 2025-03-01 

Artifacts:
  Discovered: 1 
  Downloaded: 1 50MB
  Extracted:  1

Rows:
  Received: 46,619
  Enriched: 46,619
  Saved:    46,619

Files:
  Compacted: 35 => 7

Completed: 6s

> select count(*) from aws_cost_and_usage_report;
+--------------+
| count_star() |
+--------------+
| 46,624       |
+--------------+


```
</details>
