### PR TITLE
The aws_s3_bucket source should not always append `/` to the end of prefixes Closes #85

### DIFF
--- a/docs/sources/aws_s3_bucket.md
+++ b/docs/sources/aws_s3_bucket.md
@@ -60,7 +60,7 @@ partition "aws_cloudtrail_log" "my_logs_custom_path" {
 }
 ```
 
-### Collect S3 access logs with a prefix
+### Collect S3 access logs for a specific date from non-date based partition logs
 
 Collect S3 server access logs from a flat bucket by filtering objects that start with the specified prefix.
 

--- a/docs/sources/aws_s3_bucket.md
+++ b/docs/sources/aws_s3_bucket.md
@@ -11,6 +11,8 @@ Using this source, you can collect, filter, and analyze logs stored in S3 bucket
 
 Most AWS tables define a default `file_layout` for the `aws_s3_bucket` source, so if your AWS logs are stored in default log locations, you don't need to override the `file_layout` argument.
 
+The trailing `/` is not automatically included in the `prefix`. If your log path requires it, be sure to add it explicitly.
+
 ## Example Configurations
 
 ### Collect CloudTrail logs

--- a/docs/sources/aws_s3_bucket.md
+++ b/docs/sources/aws_s3_bucket.md
@@ -60,6 +60,20 @@ partition "aws_cloudtrail_log" "my_logs_custom_path" {
 }
 ```
 
+### Collect S3 access logs with a prefix
+
+Collect S3 server access logs from a flat bucket by filtering objects that start with the specified prefix.
+
+```hcl
+partition "aws_s3_server_access_log" "my_s3_logs" {
+  source "aws_s3_bucket" {
+    connection = connection.aws.logging_account
+    bucket     = "aws-s3-server-access-logs"
+    prefix     = "2025-06-07"
+  }
+}
+```
+
 ## Arguments
 
 | Argument     | Type            | Required | Default                  | Description                                                                                                                   |

--- a/docs/sources/aws_s3_bucket.md
+++ b/docs/sources/aws_s3_bucket.md
@@ -62,7 +62,7 @@ partition "aws_cloudtrail_log" "my_logs_custom_path" {
 
 ### Collect S3 access logs for a specific date from non-date based partition logs
 
-Collect S3 server access logs from a flat bucket by filtering objects that start with the specified prefix.
+Collect logs in an S3 bucket stored with [non-date based partitioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html) using a prefix to only retrieve files for a specific day.
 
 ```hcl
 partition "aws_s3_server_access_log" "my_s3_logs" {

--- a/docs/tables/aws_s3_server_access_log/index.md
+++ b/docs/tables/aws_s3_server_access_log/index.md
@@ -168,6 +168,20 @@ partition "aws_s3_server_access_log" "my_s3_logs_prefix" {
 }
 ```
 
+### Collect logs with a prefix (without trailing slash)
+
+Collect S3 server access logs from a flat bucket by filtering objects that start with the specified prefix.
+
+```hcl
+partition "aws_s3_server_access_log" "my_s3_logs_no_trailing_slash" {
+  source "aws_s3_bucket" {
+    connection = connection.aws.logging_account
+    bucket     = "s3-server-access-logs-bucket"
+    prefix     = "2025-06-07"
+  }
+}
+```
+
 ## Source Defaults
 
 ### aws_s3_bucket

--- a/docs/tables/aws_s3_server_access_log/index.md
+++ b/docs/tables/aws_s3_server_access_log/index.md
@@ -168,9 +168,9 @@ partition "aws_s3_server_access_log" "my_s3_logs_prefix" {
 }
 ```
 
-### Collect logs with a prefix (without trailing slash)
+### Collect logs for a specific date from non-date based partition logs
 
-Collect S3 server access logs from a flat bucket by filtering objects that start with the specified prefix.
+Collect logs in an S3 bucket stored with [non-date based partitioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html) using a prefix to only retrieve files for a specific day.
 
 ```hcl
 partition "aws_s3_server_access_log" "my_s3_logs_no_trailing_slash" {

--- a/sources/s3_bucket/s3_bucket_source.go
+++ b/sources/s3_bucket/s3_bucket_source.go
@@ -237,7 +237,6 @@ func (s *AwsS3BucketSource) walkS3(ctx context.Context, bucket string, prefix st
 			}
 		}
 
-		// slog.Debug("page.Contents ===>>>>>", "contents", page.Contents)
 		// Files
 		for _, obj := range page.Contents {
 			objKey := typehelpers.SafeString(*obj.Key)


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

Config:

```
partition "aws_s3_server_access_log" "my_s3_logs_with_prefix" {
  source "aws_s3_bucket" {
    connection = connection.aws.nagraj
    bucket     = "test-s3-server-access-logs-ved"
    prefix     = "2025-06-06"
  }
}
```

Result:

```
 tpc aws_s3_server_access_log.my_s3_logs             

Collecting logs for aws_s3_server_access_log.my_s3_logs from 2025-06-03 (initial collection, default 7 days)

Artifacts:
  Discovered: 156 
  Downloaded: 156 198kB
  Extracted:  156

Rows:
  Received: 363
  Enriched: 363
  Saved:    363

Files:
  Compacted: 7 => 7

Completed: 11s
```
</details>
